### PR TITLE
Change asset hub node order

### DIFF
--- a/src/common/chainRegistry/knownChains.ts
+++ b/src/common/chainRegistry/knownChains.ts
@@ -146,16 +146,16 @@ export const assetHub: Chain = {
   ],
   nodes: [
     {
+      url: 'wss://asset-hub-polkadot-rpc.dwellir.com',
+      name: 'Dwellir node',
+    },
+    {
       url: 'wss://sys.ibp.network/statemint',
       name: 'IBP network node',
     },
     {
       url: 'wss://sys.dotters.network/statemint',
       name: 'Dotters Net node',
-    },
-    {
-      url: 'wss://statemint-rpc.dwellir.com',
-      name: 'Dwellir node',
     },
     {
       url: 'wss://statemint.api.onfinality.io/public-ws',


### PR DESCRIPTION
IBP network node does not show high performance, currently USDT balance stuck in load for the longest time

<details>
  <summary>Example</summary>

https://github.com/novasamatech/telenova-web-app/assets/40560660/58eec88a-7126-48f5-a4f8-0490e3b727cb

</details>