### PR TITLE
Feat: Asset search

### DIFF
--- a/app/common/utils/chains.ts
+++ b/app/common/utils/chains.ts
@@ -1,6 +1,23 @@
+export const POLKADOT = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3';
+export const KUSAMA = '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe';
+export const POLKADOT_ASSET_HUB = '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f';
+export const WESTEND = '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e';
+
 export const DEFAULT_CONNECTED_CHAINS: Record<ChainId, AssetId[]> = {
-  '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3': [0], // POLKADOT
-  '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe': [0], // KUSAMA
-  '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f': [1], // DOT_ASSET_HUB
-  '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e': [0], // WESTEND
+  [POLKADOT]: [0],
+  [KUSAMA]: [0],
+  [POLKADOT_ASSET_HUB]: [1],
+  [WESTEND]: [0],
+};
+
+export const DEFAULT_CHAINS_ORDER: Record<ChainId, Record<AssetId, number>> = {
+  [POLKADOT]: {
+    0: 0, // DOT - index_0
+  },
+  [KUSAMA]: {
+    0: 1, // KSM - index_1
+  },
+  [POLKADOT_ASSET_HUB]: {
+    1: 2, // USDT - index_2
+  },
 };

--- a/app/components/AmountDetails/AmountDetails.tsx
+++ b/app/components/AmountDetails/AmountDetails.tsx
@@ -5,8 +5,8 @@ import { Input } from '@nextui-org/react';
 import { Icon } from '../Icon/Icon';
 import { TokenPrice } from '../Price/TokenPrice';
 import { BodyText, LargeTitleText } from '../Typography';
-import { type IconNames } from '../types';
 
+import { AssetIcon } from '@/components';
 import { type Asset } from '@/types/substrate';
 
 //TODO: Change layout mobile text
@@ -36,13 +36,13 @@ export const AmountDetails = ({
 
   return (
     <>
-      <div className="mb-6 mt-5 grid grid-cols-[40px,1fr,auto] gap-2 h-[40px] items-center">
-        <Icon name={asset.symbol as IconNames} className="w-10 h-10" />
+      <div className="flex gap-x-2 items-center mb-6 mt-5 -ml-1.5">
+        <AssetIcon src={asset.icon} size={46} />
         <LargeTitleText>{asset.symbol}</LargeTitleText>
         <Input
           fullWidth={false}
           variant="underlined"
-          className="mt-2.5 font-manrope h-full"
+          className="font-manrope w-max ml-auto mt-2.5 "
           classNames={{ input: ['text-right !text-large-title max-w-[7ch]'] }}
           value={amount}
           isInvalid={!isAmountValid}

--- a/app/components/Assets/AssetsList.tsx
+++ b/app/components/Assets/AssetsList.tsx
@@ -1,49 +1,47 @@
 import { type ComponentProps } from 'react';
 
 import { cnTw } from '@/common/utils';
-import { type AssetBalance, type AssetsMap, type ChainBalances, type ChainsMap } from '@/types/substrate';
+import { type Asset, type AssetBalance, type ChainBalances, type ChainsMap } from '@/types/substrate';
 
 import { AssetBalance as AssetBalanceItem } from './AssetBalance';
 
 type Props = Pick<ComponentProps<typeof AssetBalanceItem>, 'animate' | 'showArrow' | 'showPrice' | 'className'> & {
   chains: ChainsMap;
-  assets: AssetsMap;
+  assets: [ChainId, Asset][];
   balances: ChainBalances;
   onClick?: (asset: AssetBalance) => void;
 };
 
 export const AssetsList = ({ chains, assets, className, balances, onClick, ...props }: Props) => {
-  return Object.entries(assets).map(([chainId, assetsMap]) => {
-    const typedChainId = chainId as ChainId;
+  return assets.map(([chainId, asset]) => {
+    const assetBalance = balances[chainId]?.[asset.assetId];
 
-    if (!assetsMap) return null;
-
-    return Object.entries(assetsMap).map(([assetId, asset]) => {
-      const assetBalance = balances[typedChainId]?.[Number(assetId) as AssetId];
-
-      if (onClick) {
-        return (
-          <button key={assetId} className={cnTw('appearance-none', className)} onClick={() => onClick(assetBalance)}>
-            <AssetBalanceItem
-              asset={asset}
-              balance={assetBalance?.balance.total}
-              name={chains[typedChainId].name}
-              {...props}
-            />
-          </button>
-        );
-      }
-
+    if (onClick) {
       return (
-        <AssetBalanceItem
-          key={asset.assetId}
-          className={className}
-          asset={asset}
-          balance={assetBalance?.balance.total}
-          name={chains[typedChainId].name}
-          {...props}
-        />
+        <button
+          key={`${chainId}_${asset.assetId}`}
+          className={cnTw('appearance-none', className)}
+          onClick={() => onClick(assetBalance)}
+        >
+          <AssetBalanceItem
+            asset={asset}
+            balance={assetBalance?.balance.total}
+            name={chains[chainId].name}
+            {...props}
+          />
+        </button>
       );
-    });
+    }
+
+    return (
+      <AssetBalanceItem
+        key={`${chainId}_${asset.assetId}`}
+        className={className}
+        asset={asset}
+        balance={assetBalance?.balance.total}
+        name={chains[chainId].name}
+        {...props}
+      />
+    );
   });
 };

--- a/app/models/balances/balances-model.test.ts
+++ b/app/models/balances/balances-model.test.ts
@@ -1,6 +1,6 @@
 import { allSettled, fork } from 'effector';
 import noop from 'lodash/noop';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { networkModel } from '../network/network-model';
 import { walletModel } from '../wallet/wallet-model';
@@ -16,6 +16,10 @@ describe('models/balances/balances-model', () => {
     '0x002': { name: 'Kusama', chainId: '0x002', assets: [{ assetId: 1 }] },
     '0x003': { name: 'Karura', chainId: '0x003', assets: [{ assetId: 0 }, { assetId: 1 }, { assetId: 2 }] },
   } as unknown as ChainsMap;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
 
   test('should update $balance on balanceUpdated', async () => {
     const defaultBalance = {

--- a/app/models/index.ts
+++ b/app/models/index.ts
@@ -1,3 +1,4 @@
 export { balancesModel } from './balances/balances-model';
 export { networkModel } from './network/network-model';
+export { assetsFilterModel } from './network/assets-filter-model';
 export { walletModel } from './wallet/wallet-model';

--- a/app/models/network/assets-filter-model.ts
+++ b/app/models/network/assets-filter-model.ts
@@ -1,0 +1,32 @@
+import { combine, createEvent, restore } from 'effector';
+import { readonly } from 'patronum';
+
+import { networkModel } from './network-model';
+
+const pageMounted = createEvent();
+const queryChanged = createEvent<string>();
+
+const $query = restore(queryChanged, '').reset(pageMounted);
+
+const $filteredAssets = combine(
+  {
+    query: $query,
+    sortedAssets: networkModel.$sortedAssets,
+  },
+  ({ query, sortedAssets }) => {
+    return sortedAssets.filter(([_, asset]) => asset.symbol.toLowerCase().includes(query));
+  },
+);
+
+export const assetsFilterModel = {
+  // Search query
+  $query: readonly($query),
+
+  // Assets sorted by symbol and filtered by query
+  $assets: readonly($filteredAssets),
+
+  input: {
+    pageMounted,
+    queryChanged,
+  },
+};

--- a/app/models/network/network-model.test.ts
+++ b/app/models/network/network-model.test.ts
@@ -1,12 +1,13 @@
 import { allSettled, fork } from 'effector';
 import { keyBy } from 'lodash-es';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { type ApiPromise } from '@polkadot/api';
 
 import { CONNECTIONS_STORE } from '@/common/utils';
+import { KUSAMA, POLKADOT, POLKADOT_ASSET_HUB } from '@/common/utils/chains.ts';
 import { chainsApi } from '@/shared/api';
-import { type Chain, type ChainMetadata } from '@/types/substrate';
+import { type AssetsMap, type Chain, type ChainMetadata } from '@/types/substrate';
 
 import { networkModel } from './network-model';
 
@@ -54,23 +55,32 @@ describe('@/common/network/network-model', () => {
   const effectMocks = {
     createProviderFx: {
       fx: networkModel._internal.createProviderFx,
-      mock: ({ chainId }: any) => ({
-        provider: {},
-        api: { genesisHash: { toHex: () => chainId } },
-      }),
+      data: () =>
+        vi.fn().mockImplementation(({ chainId }: any) => ({
+          provider: {},
+          api: { genesisHash: { toHex: () => chainId } },
+        })),
     },
     getConnectedAssetsFx: {
       fx: networkModel._internal.getConnectedAssetsFx,
-      mock: vi.fn().mockResolvedValue({}),
+      data: () => vi.fn().mockResolvedValue({}),
+    },
+    requestChainsFx: {
+      fx: networkModel._internal.requestChainsFx,
+      data: () => vi.fn().mockResolvedValue(mockedChainsMap),
     },
   };
 
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('should populate $chains on networkStarted event', async () => {
-    const fakeRequestFx = vi.fn().mockResolvedValue(mockedChainsMap);
+    const fakeRequestFx = effectMocks.requestChainsFx.data();
     const scope = fork({
       handlers: [
-        [networkModel._internal.requestChainsFx, fakeRequestFx],
-        [effectMocks.createProviderFx.fx, effectMocks.createProviderFx.mock],
+        [effectMocks.requestChainsFx.fx, fakeRequestFx],
+        [effectMocks.createProviderFx.fx, effectMocks.createProviderFx.data()],
       ],
     });
 
@@ -97,8 +107,9 @@ describe('@/common/network/network-model', () => {
 
     const scope = fork({
       handlers: [
-        [effectMocks.getConnectedAssetsFx.fx, effectMocks.getConnectedAssetsFx.mock],
-        [effectMocks.createProviderFx.fx, effectMocks.createProviderFx.mock],
+        [effectMocks.requestChainsFx.fx, effectMocks.requestChainsFx.data()],
+        [effectMocks.getConnectedAssetsFx.fx, effectMocks.getConnectedAssetsFx.data()],
+        [effectMocks.createProviderFx.fx, effectMocks.createProviderFx.data()],
       ],
     });
 
@@ -130,7 +141,7 @@ describe('@/common/network/network-model', () => {
     window.Telegram = { WebApp: { CloudStorage: { getItem } } } as any;
 
     const scope = fork({
-      handlers: [[effectMocks.createProviderFx.fx, effectMocks.createProviderFx.mock]],
+      handlers: [[effectMocks.createProviderFx.fx, effectMocks.createProviderFx.data()]],
     });
 
     await allSettled(networkModel.input.networkStarted, { scope, params: 'chains_dev' });
@@ -160,8 +171,8 @@ describe('@/common/network/network-model', () => {
         [networkModel._internal.$connections, { [mockedChains[2].chainId]: { status: 'disconnected' } }], // Karura
       ],
       handlers: [
-        [effectMocks.getConnectedAssetsFx.fx, effectMocks.getConnectedAssetsFx.mock],
-        [effectMocks.createProviderFx.fx, effectMocks.createProviderFx.mock],
+        [effectMocks.getConnectedAssetsFx.fx, effectMocks.getConnectedAssetsFx.data()],
+        [effectMocks.createProviderFx.fx, effectMocks.createProviderFx.data()],
       ],
     });
 
@@ -237,7 +248,7 @@ describe('@/common/network/network-model', () => {
           },
         ],
       ],
-      handlers: [[effectMocks.createProviderFx.fx, effectMocks.createProviderFx.mock]],
+      handlers: [[effectMocks.createProviderFx.fx, effectMocks.createProviderFx.data()]],
     });
 
     await allSettled(networkModel.input.assetConnected, {
@@ -247,5 +258,30 @@ describe('@/common/network/network-model', () => {
 
     // Polkadot asset_0 should not appear
     expect(setItemSpy).toHaveBeenCalledWith(CONNECTIONS_STORE, '2_1;');
+  });
+
+  test('should sort assets with presorted chains', async () => {
+    const mockedAssetsMap = {
+      '0x001': { 0: { assetId: 0, symbol: 'WND' } },
+      '0x002': { 0: { assetId: 0, symbol: 'KAR' } },
+      '0x003': { 0: { assetId: 0, symbol: 'GLMR' } },
+      [POLKADOT]: { 0: { assetId: 0, symbol: 'DOT' } },
+      [KUSAMA]: { 0: { assetId: 0, symbol: 'KSM' } },
+      [POLKADOT_ASSET_HUB]: { 1: { assetId: 1, symbol: 'USDT' }, 2: { assetId: 2, symbol: 'USDC' } },
+    } as unknown as AssetsMap;
+
+    const scope = fork();
+
+    await allSettled(networkModel._internal.$assets, { scope, params: mockedAssetsMap });
+
+    expect(scope.getState(networkModel.$sortedAssets)).toEqual([
+      [POLKADOT, mockedAssetsMap[POLKADOT]['0']],
+      [KUSAMA, mockedAssetsMap[KUSAMA]['0']],
+      [POLKADOT_ASSET_HUB, mockedAssetsMap[POLKADOT_ASSET_HUB]['1']],
+      ['0x003', mockedAssetsMap['0x003']['0']],
+      ['0x002', mockedAssetsMap['0x002']['0']],
+      [POLKADOT_ASSET_HUB, mockedAssetsMap[POLKADOT_ASSET_HUB]['2']],
+      ['0x001', mockedAssetsMap['0x001']['0']],
+    ]);
   });
 });

--- a/app/routes/assets/_model/assets-page-model.test.ts
+++ b/app/routes/assets/_model/assets-page-model.test.ts
@@ -72,7 +72,7 @@ describe('routes/assets/_model/assets-page-model', () => {
     });
 
     await allSettled(networkModel._internal.$chains, { scope, params: mockedChains });
-    await allSettled(assetsPageModel.inputs.pageMounted, { scope });
+    await allSettled(assetsPageModel.input.pageMounted, { scope });
 
     expect(scope.getState(assetsPageModel.$assets)).toEqual([
       ['0x006', { assetId: 2, symbol: 'GLMR_0' }, true],
@@ -89,7 +89,7 @@ describe('routes/assets/_model/assets-page-model', () => {
     });
 
     await allSettled(networkModel._internal.$chains, { scope, params: mockedChains });
-    await allSettled(assetsPageModel.inputs.queryChanged, { scope, params: 'ar' });
+    await allSettled(assetsPageModel.input.queryChanged, { scope, params: 'ar' });
 
     expect(scope.getState(assetsPageModel.$assets)).toEqual([
       ['0x005', { assetId: 2, symbol: 'KAR_2' }, true],

--- a/app/routes/assets/_model/assets-page-model.ts
+++ b/app/routes/assets/_model/assets-page-model.ts
@@ -11,7 +11,7 @@ const pageMounted = createEvent();
 const queryChanged = createEvent<string>();
 const assetToggled = createEvent<{ chainId: ChainId; assetId: AssetId; selected: boolean }>();
 
-const $query = restore(queryChanged, '');
+const $query = restore(queryChanged, '').reset(pageMounted);
 const $filteredAssets = createStore<[ChainId, Asset, boolean][]>([]);
 
 const $sortedAssets = combine(networkModel.$chains, chains => {
@@ -83,7 +83,7 @@ export const assetsPageModel = {
   $assets: readonly($filteredAssets),
   $query: readonly($query),
 
-  inputs: {
+  input: {
     pageMounted,
     queryChanged,
     assetToggled,

--- a/app/routes/assets/index.tsx
+++ b/app/routes/assets/index.tsx
@@ -16,11 +16,11 @@ const Page = () => {
   const assets = useUnit(assetsPageModel.$assets);
 
   useEffect(() => {
-    assetsPageModel.inputs.pageMounted();
+    assetsPageModel.input.pageMounted();
   }, []);
 
   const toggleAsset = (chainId: ChainId, assetId: AssetId) => (selected: boolean) => {
-    assetsPageModel.inputs.assetToggled({ chainId, assetId, selected });
+    assetsPageModel.input.assetToggled({ chainId, assetId, selected });
   };
 
   return (
@@ -35,8 +35,8 @@ const Page = () => {
           className="h-12"
           startContent={<Icon name="Search" size={16} className="text-text-hint" />}
           value={query}
-          onValueChange={assetsPageModel.inputs.queryChanged}
-          onClear={() => assetsPageModel.inputs.queryChanged('')}
+          onValueChange={assetsPageModel.input.queryChanged}
+          onClear={() => assetsPageModel.input.queryChanged('')}
         />
 
         {assets.length > 0 && (

--- a/app/routes/dashboard/index.tsx
+++ b/app/routes/dashboard/index.tsx
@@ -32,7 +32,7 @@ const Page = () => {
   const { assetsPrices, setAssetsPrices } = useGlobalContext();
 
   const chains = useUnit(networkModel.$chains);
-  const assets = useUnit(networkModel.$assets);
+  const assets = useUnit(networkModel.$sortedAssets);
   const balances = useUnit(balancesModel.$balances);
 
   // Fetching chains

--- a/app/routes/exchange/select.tsx
+++ b/app/routes/exchange/select.tsx
@@ -5,18 +5,19 @@ import { useUnit } from 'effector-react';
 import { $path } from 'remix-routes';
 
 import { BackButton } from '@/common/telegram/BackButton';
-import { nonNullable } from '@/common/utils';
+import { KUSAMA, POLKADOT } from '@/common/utils/chains.ts';
 import { AssetBalance, TitleText } from '@/components';
 import { balancesModel, networkModel } from '@/models';
-import { type Asset } from '@/types/substrate';
 
 export type SearchParams = {
   type: 'buy' | 'sell';
 };
 
-const ASSETS_TO_SKIP: Record<ChainId, AssetId> = {
-  '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e': 0, // WND,
-  '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f': 1, // Polkadot AH - USDT
+// Mercuryo supported cryptocurrencies:
+// https://help.mercuryo.io/hc/en-gb/articles/14495549158045-Which-cryptocurrencies-are-supported
+const SUPPORTED_ASSETS: Record<ChainId, AssetId> = {
+  [POLKADOT]: 0, // DOT
+  [KUSAMA]: 0, // KSM
 };
 
 export const clientLoader = (({ request }) => {
@@ -31,45 +32,30 @@ const Page = () => {
   const navigate = useNavigate();
 
   const chains = useUnit(networkModel.$chains);
-  const assets = useUnit(networkModel.$assets);
+  const assets = useUnit(networkModel.$sortedAssets);
   const balances = useUnit(balancesModel.$balances);
 
-  const exchangeAssets = Object.entries(assets)
-    .map(([chainId, assetMap]) => {
-      const typedChainId = chainId as ChainId;
-
-      if (!assetMap) return null;
-      if (!(typedChainId in ASSETS_TO_SKIP)) return [typedChainId, Object.values(assetMap)];
-
-      const filteredAssets = Object.values(assetMap)
-        .map(asset => (ASSETS_TO_SKIP[typedChainId] !== asset.assetId ? asset : null))
-        .filter(nonNullable);
-
-      return [typedChainId, filteredAssets];
-    })
-    .filter(nonNullable) as Array<[ChainId, Asset[]]>;
+  const exchangeAssets = assets.filter(([chainId, asset]) => SUPPORTED_ASSETS[chainId] === asset.assetId);
 
   return (
     <>
       <BackButton onClick={() => navigate($path('/exchange'))} />
       <TitleText className="mt-6 mb-10">Select a token {type ? `to ${type}` : ''}</TitleText>
       <div className="flex flex-col gap-2 mt-4">
-        {exchangeAssets.flatMap(([chainId, assets]) => {
-          return assets.map(asset => (
-            <Link
-              key={`${chainId}_${asset.assetId}`}
-              to={$path('/exchange/widget/:chainId/:assetId', { chainId, assetId: asset.assetId }, { type })}
-            >
-              <AssetBalance
-                asset={asset}
-                balance={balances[chainId][asset.assetId].balance.total}
-                className="bg-white rounded-lg px-4 py-3 w-full hover:bg-bg-item-pressed active:bg-bg-item-pressed"
-                name={chains[chainId].name}
-                showArrow
-              />
-            </Link>
-          ));
-        })}
+        {exchangeAssets.map(([chainId, asset]) => (
+          <Link
+            key={`${chainId}_${asset.assetId}`}
+            to={$path('/exchange/widget/:chainId/:assetId', { chainId, assetId: asset.assetId }, { type })}
+          >
+            <AssetBalance
+              asset={asset}
+              balance={balances[chainId]?.[asset.assetId]?.balance.total}
+              className="bg-white rounded-lg px-4 py-3 w-full hover:bg-bg-item-pressed active:bg-bg-item-pressed"
+              name={chains[chainId].name}
+              showArrow
+            />
+          </Link>
+        ))}
       </div>
     </>
   );

--- a/app/routes/receive/token-select.tsx
+++ b/app/routes/receive/token-select.tsx
@@ -1,19 +1,25 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useUnit } from 'effector-react';
 import { $path } from 'remix-routes';
 
 import { BackButton } from '@/common/telegram/BackButton';
-import { AssetsList, TitleText } from '@/components';
-import { balancesModel, networkModel } from '@/models';
+import { AssetsList, BodyText, Icon, Input, TitleText } from '@/components';
+import { assetsFilterModel, balancesModel, networkModel } from '@/models';
 import { type AssetBalance } from '@/types/substrate';
 
 const Page = () => {
   const navigate = useNavigate();
 
   const chains = useUnit(networkModel.$chains);
-  const assets = useUnit(networkModel.$assets);
   const balances = useUnit(balancesModel.$balances);
+  const query = useUnit(assetsFilterModel.$query);
+  const assets = useUnit(assetsFilterModel.$assets);
+
+  useEffect(() => {
+    assetsFilterModel.input.pageMounted();
+  }, []);
 
   const navigateToAddress = (asset: AssetBalance) => {
     navigate(
@@ -27,16 +33,38 @@ const Page = () => {
   return (
     <>
       <BackButton onClick={() => navigate($path('/dashboard'))} />
-      <TitleText className="mt-6 mb-10">Select a token to receive</TitleText>
-      <div className="flex flex-col gap-2 mt-4">
-        <AssetsList
-          className="bg-white rounded-lg px-4 py-3 w-full hover:bg-bg-item-pressed active:bg-bg-item-pressed"
-          showArrow
-          chains={chains}
-          assets={assets}
-          balances={balances}
-          onClick={navigateToAddress}
+      <div className="flex flex-col gap-y-4">
+        <TitleText align="left">Select a token to receive</TitleText>
+        <Input
+          isClearable
+          variant="flat"
+          placeholder="Search"
+          className="h-12"
+          startContent={<Icon name="Search" size={16} className="text-text-hint" />}
+          value={query}
+          onValueChange={assetsFilterModel.input.queryChanged}
+          onClear={() => assetsFilterModel.input.queryChanged('')}
         />
+
+        {assets.length > 0 && (
+          <div className="flex flex-col gap-y-2">
+            <AssetsList
+              className="bg-white rounded-lg px-4 py-3 w-full hover:bg-bg-item-pressed active:bg-bg-item-pressed"
+              showArrow
+              chains={chains}
+              assets={assets}
+              balances={balances}
+              onClick={navigateToAddress}
+            />
+          </div>
+        )}
+
+        {assets.length === 0 && (
+          <div className="flex flex-col gap-y-4 items-center mt-[70px]">
+            <Icon name="NoResult" size={180} />
+            <BodyText className="max-w-[225px] text-text-hint">Nothing to show here based on your search </BodyText>
+          </div>
+        )}
       </div>
     </>
   );

--- a/app/routes/transfer/direct/token-select.tsx
+++ b/app/routes/transfer/direct/token-select.tsx
@@ -1,19 +1,25 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useUnit } from 'effector-react';
 import { $path } from 'remix-routes';
 
 import { BackButton } from '@/common/telegram/BackButton';
-import { AssetsList, TitleText } from '@/components';
-import { balancesModel, networkModel } from '@/models';
+import { AssetsList, BodyText, Icon, Input, TitleText } from '@/components';
+import { assetsFilterModel, balancesModel, networkModel } from '@/models';
 import { type AssetBalance } from '@/types/substrate';
 
 const Page = () => {
   const navigate = useNavigate();
 
   const chains = useUnit(networkModel.$chains);
-  const assets = useUnit(networkModel.$assets);
   const balances = useUnit(balancesModel.$balances);
+  const query = useUnit(assetsFilterModel.$query);
+  const assets = useUnit(assetsFilterModel.$assets);
+
+  useEffect(() => {
+    assetsFilterModel.input.pageMounted();
+  }, []);
 
   const navigateToAddress = (asset: AssetBalance) => {
     navigate(
@@ -27,16 +33,38 @@ const Page = () => {
   return (
     <>
       <BackButton onClick={() => navigate($path('/transfer'))} />
-      <TitleText className="mt-6 mb-10">Select a token to send</TitleText>
-      <div className="flex flex-col gap-2 mt-4">
-        <AssetsList
-          showArrow
-          chains={chains}
-          assets={assets}
-          balances={balances}
-          className="bg-white rounded-lg px-4 py-3 w-full hover:bg-bg-item-pressed active:bg-bg-item-pressed"
-          onClick={navigateToAddress}
+      <div className="flex flex-col gap-y-4">
+        <TitleText align="left">Select a token to send</TitleText>
+        <Input
+          isClearable
+          variant="flat"
+          placeholder="Search"
+          className="h-12"
+          startContent={<Icon name="Search" size={16} className="text-text-hint" />}
+          value={query}
+          onValueChange={assetsFilterModel.input.queryChanged}
+          onClear={() => assetsFilterModel.input.queryChanged('')}
         />
+
+        {assets.length > 0 && (
+          <div className="flex flex-col gap-y-2">
+            <AssetsList
+              className="bg-white rounded-lg px-4 py-3 w-full hover:bg-bg-item-pressed active:bg-bg-item-pressed"
+              showArrow
+              chains={chains}
+              assets={assets}
+              balances={balances}
+              onClick={navigateToAddress}
+            />
+          </div>
+        )}
+
+        {assets.length === 0 && (
+          <div className="flex flex-col gap-y-4 items-center mt-[70px]">
+            <Icon name="NoResult" size={180} />
+            <BodyText className="max-w-[225px] text-text-hint">Nothing to show here based on your search </BodyText>
+          </div>
+        )}
       </div>
     </>
   );

--- a/app/routes/transfer/gift/token-select.tsx
+++ b/app/routes/transfer/gift/token-select.tsx
@@ -1,19 +1,25 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useUnit } from 'effector-react';
 import { $path } from 'remix-routes';
 
 import { BackButton } from '@/common/telegram/BackButton';
-import { AssetsList, TitleText } from '@/components';
-import { balancesModel, networkModel } from '@/models';
+import { AssetsList, BodyText, Icon, Input, TitleText } from '@/components';
+import { assetsFilterModel, balancesModel, networkModel } from '@/models';
 import { type AssetBalance } from '@/types/substrate';
 
 const Page = () => {
   const navigate = useNavigate();
 
   const chains = useUnit(networkModel.$chains);
-  const assets = useUnit(networkModel.$assets);
   const balances = useUnit(balancesModel.$balances);
+  const query = useUnit(assetsFilterModel.$query);
+  const assets = useUnit(assetsFilterModel.$assets);
+
+  useEffect(() => {
+    assetsFilterModel.input.pageMounted();
+  }, []);
 
   const navigateToAmount = (asset: AssetBalance) => {
     navigate(
@@ -27,16 +33,38 @@ const Page = () => {
   return (
     <>
       <BackButton onClick={() => navigate($path('/transfer'))} />
-      <TitleText className="mt-6 mb-10">Select a token to send</TitleText>
-      <div className="flex flex-col gap-2 mt-4">
-        <AssetsList
-          showArrow
-          chains={chains}
-          assets={assets}
-          balances={balances}
-          className="bg-white rounded-lg px-4 py-3 w-full hover:bg-bg-item-pressed active:bg-bg-item-pressed"
-          onClick={navigateToAmount}
+      <div className="flex flex-col gap-y-4">
+        <TitleText align="left">Select a token to send</TitleText>
+        <Input
+          isClearable
+          variant="flat"
+          placeholder="Search"
+          className="h-12"
+          startContent={<Icon name="Search" size={16} className="text-text-hint" />}
+          value={query}
+          onValueChange={assetsFilterModel.input.queryChanged}
+          onClear={() => assetsFilterModel.input.queryChanged('')}
         />
+
+        {assets.length > 0 && (
+          <div className="flex flex-col gap-y-2">
+            <AssetsList
+              className="bg-white rounded-lg px-4 py-3 w-full hover:bg-bg-item-pressed active:bg-bg-item-pressed"
+              showArrow
+              chains={chains}
+              assets={assets}
+              balances={balances}
+              onClick={navigateToAmount}
+            />
+          </div>
+        )}
+
+        {assets.length === 0 && (
+          <div className="flex flex-col gap-y-4 items-center mt-[70px]">
+            <Icon name="NoResult" size={180} />
+            <BodyText className="max-w-[225px] text-text-hint">Nothing to show here based on your search </BodyText>
+          </div>
+        )}
       </div>
     </>
   );

--- a/app/shared/api/network/chain-api.ts
+++ b/app/shared/api/network/chain-api.ts
@@ -1,6 +1,7 @@
 import { concat, sortBy } from 'lodash-es';
 
 import { nonNullable } from '@/common/utils';
+import { KUSAMA, POLKADOT } from '@/common/utils/chains';
 import { type Chain } from '@/types/substrate';
 
 export const chainsApi = {
@@ -34,17 +35,12 @@ function sortChains(chains: Chain[]): Chain[] {
   return concat([polkadot, kusama].filter(nonNullable), sortBy(parachains, 'name'), sortBy(numberchains, 'name'));
 }
 
-const RelayChains = {
-  POLKADOT: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
-  KUSAMA: '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe',
-  WESTEND: '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e',
-};
 function isPolkadot(chain: Chain): boolean {
-  return chain.chainId === RelayChains.POLKADOT;
+  return chain.chainId === POLKADOT;
 }
 
 function isKusama(chain: Chain): boolean {
-  return chain.chainId === RelayChains.KUSAMA;
+  return chain.chainId === KUSAMA;
 }
 
 function isNameStartsWithNumber(chain: Chain): boolean {

--- a/app/types/remix-routes.d.ts
+++ b/app/types/remix-routes.d.ts
@@ -10,10 +10,10 @@ declare module 'remix-routes' {
       params: never;
       query: ExportedQuery<import('../root').SearchParams>;
     };
-  
-    "/assets": {
-      params: never,
-      query: ExportedQuery<import('../routes/assets/index').SearchParams>,
+
+    '/assets': {
+      params: never;
+      query: ExportedQuery<import('../routes/assets/index').SearchParams>;
     };
 
     '/dashboard': {

--- a/app/types/substrate/asset.ts
+++ b/app/types/substrate/asset.ts
@@ -27,4 +27,4 @@ export type PriceItem = {
   change?: number;
 };
 
-export type AssetsMap = Record<ChainId, Record<AssetId, Asset> | undefined>;
+export type AssetsMap = Record<ChainId, Record<AssetId, Asset>>;


### PR DESCRIPTION
- Search by asset symbol on receive & send pages
- Sorted asset list (DOT > KSM > USDT > other parachains alphabetically)
- Updated assets filtering for Mercuryo widget
- UI fixes
- Test

= [Task](https://app.clickup.com/t/869502ja7) =

<img width="481" alt="image" src="https://github.com/user-attachments/assets/89977ef6-ad5c-4fea-9d9e-36529d31523b">
